### PR TITLE
chore: clean up repo after extraction from planningcenter/design

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2021-04-20
+
+### Added
+
+- Added a CHANGELOG!
+- Initial CHANGELOG entry. Version 1.0.0 is the same effective code as version 0.0.4.
+
+### Changed
+
+- Updated package.json entries after package extraction from the planningcenter/design monorepo
+
+[1.0.0]: https://github.com/planningcenter/reach/compare/v0.0.4..v1.0.0

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@planningcenter/reach",
   "version": "0.0.4",
   "description": "Reach UI stylesheets with custom property controls",
-  "author": "Michael Chan <mijoch@gmail.com>",
-  "homepage": "https://github.com/planningcenter/design#readme",
+  "author": "Front End Systems Engineering <frontend@planningcenter.com>",
+  "homepage": "https://github.com/planningcenter/reach",
   "license": "MIT",
   "files": [
     "css"
@@ -13,10 +13,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/planningcenter/design.git"
+    "url": "git+https://github.com/planningcenter/reach"
   },
   "scripts": {},
   "bugs": {
-    "url": "https://github.com/planningcenter/design/issues"
+    "url": "https://github.com/planningcenter/reach/issues"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@planningcenter/reach",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "description": "Reach UI stylesheets with custom property controls",
   "author": "Front End Systems Engineering <frontend@planningcenter.com>",
   "homepage": "https://github.com/planningcenter/reach",


### PR DESCRIPTION
Most of this follows the Notion document outlining how the Front End Systems Engineering team handles the packages it oversees. In short:

- prefer yarn over npm
- have a github workflow that builds and tests the package
- ensure at least one test
- prettier/eslint enabled and managing styles

However, this package is css only and there are no dependencies or build steps and nothing to test. So really, this is simply cleaning up some things after the extraction.

This package was extracted from the [design](https://github.com/planningcenter/design) monorepo in https://github.com/planningcenter/design/pull/170.